### PR TITLE
Client can now view a park locations on a map

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,9 +12,11 @@
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
         "bootstrap": "^5.2.3",
+        "leaflet": "^1.9.3",
         "react": "^18.2.0",
         "react-bootstrap": "^2.7.0",
         "react-dom": "^18.2.0",
+        "react-leaflet": "^4.2.0",
         "react-router-dom": "^6.7.0",
         "react-scripts": "5.0.1",
         "web-vitals": "^2.1.4"
@@ -3098,6 +3100,16 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+      }
+    },
+    "node_modules/@react-leaflet/core": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@react-leaflet/core/-/core-2.1.0.tgz",
+      "integrity": "sha512-Qk7Pfu8BSarKGqILj4x7bCSZ1pjuAPZ+qmRwH5S7mDS91VSbVVsJSrW4qA+GPrro8t69gFYVMWb1Zc4yFmPiVg==",
+      "peerDependencies": {
+        "leaflet": "^1.9.0",
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
       }
     },
     "node_modules/@remix-run/router": {
@@ -11730,6 +11742,11 @@
         "language-subtag-registry": "~0.3.2"
       }
     },
+    "node_modules/leaflet": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.3.tgz",
+      "integrity": "sha512-iB2cR9vAkDOu5l3HAay2obcUHZ7xwUBBjph8+PGtmW/2lYhbLizWtG7nTeYht36WfOslixQF9D/uSIzhZgGMfQ=="
+    },
     "node_modules/leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -14389,6 +14406,19 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
+    },
+    "node_modules/react-leaflet": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/react-leaflet/-/react-leaflet-4.2.0.tgz",
+      "integrity": "sha512-9d8T7hzYrQA5GLe3vn0qtRLJzQKgjr080NKa45yArGwuSl1nH/6aK9gp7DeYdktpdO1vKGSUTGW5AsUS064X0A==",
+      "dependencies": {
+        "@react-leaflet/core": "^2.1.0"
+      },
+      "peerDependencies": {
+        "leaflet": "^1.9.0",
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
     },
     "node_modules/react-lifecycles-compat": {
       "version": "3.0.4",
@@ -19406,6 +19436,12 @@
       "requires": {
         "@swc/helpers": "^0.4.14"
       }
+    },
+    "@react-leaflet/core": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@react-leaflet/core/-/core-2.1.0.tgz",
+      "integrity": "sha512-Qk7Pfu8BSarKGqILj4x7bCSZ1pjuAPZ+qmRwH5S7mDS91VSbVVsJSrW4qA+GPrro8t69gFYVMWb1Zc4yFmPiVg==",
+      "requires": {}
     },
     "@remix-run/router": {
       "version": "1.3.0",
@@ -25713,6 +25749,11 @@
         "language-subtag-registry": "~0.3.2"
       }
     },
+    "leaflet": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.3.tgz",
+      "integrity": "sha512-iB2cR9vAkDOu5l3HAay2obcUHZ7xwUBBjph8+PGtmW/2lYhbLizWtG7nTeYht36WfOslixQF9D/uSIzhZgGMfQ=="
+    },
     "leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -27455,6 +27496,14 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
+    },
+    "react-leaflet": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/react-leaflet/-/react-leaflet-4.2.0.tgz",
+      "integrity": "sha512-9d8T7hzYrQA5GLe3vn0qtRLJzQKgjr080NKa45yArGwuSl1nH/6aK9gp7DeYdktpdO1vKGSUTGW5AsUS064X0A==",
+      "requires": {
+        "@react-leaflet/core": "^2.1.0"
+      }
     },
     "react-lifecycles-compat": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -7,9 +7,11 @@
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
     "bootstrap": "^5.2.3",
+    "leaflet": "^1.9.3",
     "react": "^18.2.0",
     "react-bootstrap": "^2.7.0",
     "react-dom": "^18.2.0",
+    "react-leaflet": "^4.2.0",
     "react-router-dom": "^6.7.0",
     "react-scripts": "5.0.1",
     "web-vitals": "^2.1.4"

--- a/public/index.html
+++ b/public/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
         <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM" crossorigin="anonymous"></script>
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
@@ -27,6 +27,13 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
     <title>Park Explorer</title>
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.3/dist/leaflet.css"
+    integrity="sha256-kLaT2GOSpHechhsozzB+flnD+zUyjE2LlfWPgU04xyI="
+    crossorigin=""/>
+    <!-- Make sure you put this AFTER Leaflet's CSS -->
+    <script src="https://unpkg.com/leaflet@1.9.3/dist/leaflet.js"
+    integrity="sha256-WBkoXOwTeyKclOHuWtc+i2uENFpDZ9YPdf5Hf+D7ewM="
+    crossorigin=""></script>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/components/landing/DisplayParks.js
+++ b/src/components/landing/DisplayParks.js
@@ -1,0 +1,37 @@
+import { useState } from "react";
+import { ParksMap } from "../map/ParksMap";
+import { ParkList } from "../parks/ParksList";
+import './displayParks.css'
+
+export const DisplayParks = () => {
+    const [enabled, setEnabled] = useState(true);
+
+    return <> 
+        <div className="titleContainer">
+            <h2 className="parks__title">Visit a National Park</h2>
+        </div>
+        {       
+            enabled ?
+                <>
+                    <div className="parksContainer">
+                        <label className="switch">
+                            <input type="checkbox" onClick={() => setEnabled(!enabled)}/>
+                            <span className="slider round"></span>
+                        </label>
+                        <h5 className="switchTitle">View List of Parks</h5>
+                    </div>
+                    < ParksMap />
+                </>
+            : <>
+                <div className="parksContainer">
+                    <label className="switch">
+                        <input type="checkbox" onClick={() => setEnabled(!enabled)}/>
+                        <span className="slider round"></span>
+                    </label>
+                    <h5 className="switchTitle">View Map of Parks</h5>
+                </div>
+                < ParkList />
+            </>
+        }   
+    </>
+}

--- a/src/components/landing/Landing.js
+++ b/src/components/landing/Landing.js
@@ -1,7 +1,6 @@
 import { PhotoCarousel } from "./PhotoCarousel"
-import { ParkList } from "../parks/ParksList"
 import { useState, useEffect } from "react"
-import { ParksMap } from "../map/ParksMap"
+import { DisplayParks } from "./DisplayParks"
 
 export const Landing = () => {
     const [photos, setPhotos] = useState([])
@@ -19,8 +18,7 @@ export const Landing = () => {
 
     return <>
         <PhotoCarousel resource={photos} />
-        <ParksMap />
-        <ParkList />
+        <DisplayParks />
     </>
 }
 

--- a/src/components/landing/Landing.js
+++ b/src/components/landing/Landing.js
@@ -1,6 +1,7 @@
 import { PhotoCarousel } from "./PhotoCarousel"
 import { ParkList } from "../parks/ParksList"
 import { useState, useEffect } from "react"
+import { ParksMap } from "../map/ParksMap"
 
 export const Landing = () => {
     const [photos, setPhotos] = useState([])
@@ -16,9 +17,10 @@ export const Landing = () => {
         []
     )
 
-    console.log(photos)
     return <>
-            <PhotoCarousel resource={photos} />
+        <PhotoCarousel resource={photos} />
+        <ParksMap />
         <ParkList />
     </>
 }
+

--- a/src/components/landing/PhotoCarousel.js
+++ b/src/components/landing/PhotoCarousel.js
@@ -45,7 +45,7 @@ export const PhotoCarousel = ({resource}) => {
     const LandingCarousel = () => {
     return <>
     <div id="landing--top">
-    <h1 className="title--main">Park Explorer: Discover <span></span></h1>
+    <h1 className="title--main">Park Explorer: Discover <span id="taglines"></span></h1>
     <div className="carousel">
         <button className="carousel--button prev" onClick={() => prevButtonPressed(true)} >&#171;</button>
         <button className="carousel--button next" onClick={() => nextButtonPressed(true)}>&#187;</button>

--- a/src/components/landing/displayParks.css
+++ b/src/components/landing/displayParks.css
@@ -1,0 +1,81 @@
+/* The switch - the box around the slider */
+.switch {
+    position: relative;
+    align-self: center;
+    width: 60px;
+    height: 34px;
+    justify-self: center;
+    margin: 0.5rem;
+  }
+
+  .switchTitle {
+    margin: 0.5rem;    
+  }
+  
+  /* Hide default HTML checkbox */
+  .switch input {
+    opacity: 0;
+    width: 0;
+    height: 0;
+  }
+  
+  /* The slider */
+  .slider {
+    position: absolute;
+    cursor: pointer;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: green;
+    -webkit-transition: .4s;
+    transition: .4s;
+  }
+  
+  .slider:before {
+    position: absolute;
+    content: "";
+    height: 26px;
+    width: 26px;
+    left: 4px;
+    bottom: 4px;
+    background-color: white;
+    -webkit-transition: .4s;
+    transition: .4s;
+  }
+  
+  input:checked + .slider {
+    background-color: green;
+  }
+  
+  input:focus + .slider {
+    box-shadow: 0 0 1px green;
+  }
+  
+  input:checked + .slider:before {
+    -webkit-transform: translateX(26px);
+    -ms-transform: translateX(26px);
+    transform: translateX(26px);
+  }
+  
+  /* Rounded sliders */
+  .slider.round {
+    border-radius: 34px;
+  }
+  
+  .slider.round:before {
+    border-radius: 50%;
+  }
+
+  .titleContainer {
+    display: flex;
+    justify-content: center;
+    margin: 1rem;
+  }
+
+  .parksContainer {
+    display: flex;
+  }
+
+
+ 

--- a/src/components/landing/landing.css
+++ b/src/components/landing/landing.css
@@ -95,7 +95,7 @@
     right: 1rem;
 }
 
-span::before{
+#taglines::before{
     content: '';
     animation: animate infinite 15s;
 }
@@ -120,3 +120,5 @@ span::before{
         content: 'National Parks';
     }
 }
+
+#map { height: 180px; }

--- a/src/components/map/ParksMap.js
+++ b/src/components/map/ParksMap.js
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
-import { MapContainer, TileLayer, useMap, Marker, Popup } from 'react-leaflet'
+import { MapContainer, TileLayer, Marker, Popup } from 'react-leaflet'
 import { getParks } from "../utilities/ParkManager"
+import { Link } from 'react-router-dom'
 
 export const ParksMap = () => {
     const [parks, setParks] = useState([])
@@ -26,7 +27,7 @@ export const ParksMap = () => {
                     return <Marker position={[park.latitude, park.longitude]} key={park.id}>
                         <Popup>
                             <div style={{textAlign: 'center'}}>
-                                <div>{park.name}</div>
+                                <div><Link to={`/parks/${park.id}`} className="link_styles"><h5>{park.name}</h5></Link></div>
                                 <div style={{fontStyle: 'italic'}}>{park.city}, {park.state}</div>
                             </div>
                         </Popup>

--- a/src/components/map/ParksMap.js
+++ b/src/components/map/ParksMap.js
@@ -1,0 +1,38 @@
+import { useEffect, useState } from 'react'
+import { MapContainer, TileLayer, useMap, Marker, Popup } from 'react-leaflet'
+import { getParks } from "../utilities/ParkManager"
+
+export const ParksMap = () => {
+    const [parks, setParks] = useState([])
+
+    useEffect(
+        () => {
+            getParks()
+            .then( (parksArray) => {
+                setParks(parksArray)
+            }) 
+        },
+        []
+    )
+
+    return <>
+        <MapContainer center={[44.96, -103.46]} zoom={3} scrollWheelZoom={false} style={{ height: "500px" }}>
+            <TileLayer
+            attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+            url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+            />
+            {
+                parks.map( park => {
+                    return <Marker position={[park.latitude, park.longitude]} key={park.id}>
+                        <Popup>
+                            <div style={{textAlign: 'center'}}>
+                                <div>{park.name}</div>
+                                <div style={{fontStyle: 'italic'}}>{park.city}, {park.state}</div>
+                            </div>
+                        </Popup>
+                    </Marker>       
+                })
+            }
+        </MapContainer>
+    </>
+}

--- a/src/components/parks/Park.js
+++ b/src/components/parks/Park.js
@@ -19,9 +19,11 @@ export const Park = ({ park }) => {
     )      
 
     return <>
-        <section className="park" key={`park--${park.id}`}>
-            <div className="park--name"><Link to={`/parks/${park.id}`} className="link_styles"><h5>{park.name}</h5></Link></div>
-            <img className="park--photo"src={photo} alt="National Park"/>
-        </section>
+        <div>
+            <section className="park" key={`park--${park.id}`}>
+                <div className="park--name"><Link to={`/parks/${park.id}`} className="link_styles"><h5>{park.name}</h5></Link></div>
+                <img className="park--photo"src={photo} alt="National Park"/>
+            </section>
+        </div>
         </>
 }

--- a/src/components/parks/ParksList.js
+++ b/src/components/parks/ParksList.js
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react"
 import { Park } from "./Park"
 import "./parks.css" 
+import { getParks } from "../utilities/ParkManager"
 
 
 export const ParkList = () => {
@@ -8,11 +9,10 @@ export const ParkList = () => {
 
     useEffect(
         () => {
-            fetch(`http://localhost:8000/parks`)
-            .then( res => res.json() )
+            getParks()
             .then( (parksArray) => {
                 setParks(parksArray)
-            })  
+            }) 
         },
         []
     )

--- a/src/components/utilities/ParkManager.js
+++ b/src/components/utilities/ParkManager.js
@@ -1,0 +1,5 @@
+
+export const getParks = () => {
+    return fetch(`http://localhost:8000/parks`)
+        .then( res => res.json() ) 
+}


### PR DESCRIPTION
Closes #6 

# Description
- Created a ParksMap.js component that uses React Leaflet to render a map of park locations
- Created a DisplayParks.js component which uses a toggle switch to display either a list of parks (ParkList.js) or a map of parks (ParksMap.js)
- Created a ParkManager.js component to handle common park_view.py fetch requests

# Steps to Test 

- Run the below commands in terminal

```
git fetch origin vs-parks-map
git checkout vs-parks-map
```

- React, React DOM and Leaflet are required peer dependencies. You must add them to your project if they are not already installed:

```
npm install react react-dom leaflet
npm install react-leaflet
```

- Start / refresh the React app 
- Verify the map renders as the default component on the Landing page
- Click on the park name on a map marker and verify the app routes to the park's individual page 
- Toggle the switch to see the parks list 
- Verify the parks list displays