### PR TITLE
fixed event modals

### DIFF
--- a/src/components/event/Event.js
+++ b/src/components/event/Event.js
@@ -20,7 +20,7 @@ export const Event = ({ event, setViewingEvent, setShowingEventForm, deleteEvent
   }
   
     return (
-      <Modal onClose={() => setViewingEvent(null)} title={`${event.name} (${event.park.name})`} className="eventModal">
+      <Modal onOpen={() => setShowingEventForm(false)} onClose={() => setViewingEvent(null)} title={`${event.name} (${event.park.name})`} className="eventModal">
         <p>From <b>{event.start_date}</b> to <b>{event.end_date}</b></p>
         <p>{event.description}</p>
         <FavoriteBtn resource={"events"} resource_id={Number(event.id)}/>

--- a/src/components/event/EventForm.js
+++ b/src/components/event/EventForm.js
@@ -70,7 +70,7 @@ export const EventForm = ({ setShowingEventForm, addEvent, editEvent, withEvent,
           ) : (
               <Fragment>
               <button onClick={() => addEvent(event)}>Add event to calendar</button>
-              <a className="close" href="javascript:;" onClick={() => setShowingEventForm({ visible: false })}>Cancel (go back to calendar)</a>
+              <a className="close" href="javascript:;" onClick={() => [setShowingEventForm({ visible: false }), setViewingEvent(false)]}>Cancel (go back to calendar)</a>
             </Fragment>
           )}
         </div>

--- a/src/components/event/Grid.js
+++ b/src/components/event/Grid.js
@@ -29,10 +29,10 @@ export const Grid = ({ date, events, setViewingEvent, setShowingEventForm, actua
               className={`cell ${date.date.getTime() == currentDate.getTime() ? "current" : ""} ${date.date.getMonth() != actualDate.getMonth() ? "otherMonth" : ""}`
                           }>
               <div className="date">
-                {date.date.getDate()}<a href="javascript:;" className="addEventOnDay" onClick={() => setShowingEventForm({ visible: true, preselectedDate: date.date })}>+</a>
+                {date.date.getDate()}<a href="javascript:;" className="addEventOnDay" onClick={() => [setShowingEventForm({ visible: true, preselectedDate: date.date }), setViewingEvent(false)]}>+</a>
               </div>
               {date.events.map((event, index) => 
-                              <MiniEvent key={index} event={event} setViewingEvent={setViewingEvent} />
+                              <MiniEvent key={index} event={event} setViewingEvent={setViewingEvent} setShowingEventForm={setShowingEventForm} />
                           )}
             </div>
           )

--- a/src/components/event/Utilities.js
+++ b/src/components/event/Utilities.js
@@ -100,13 +100,13 @@ export const DayLabels = () => {
   
   // An individual event displayed within the calendar grid itself
   // can be clicked to open the main event view
-  export const MiniEvent = ({ event, setViewingEvent }) => {
+  export const MiniEvent = ({ event, setViewingEvent, setShowingEventForm }) => {
     const firstWord = event.park.name ? event.park.name.split(" ")[0] : "standard";
   
     return (
       <div 
         className={`miniEvent ${firstWord}`} 
-        onClick={() => setViewingEvent(event)}
+        onClick={() => [setViewingEvent(event), setShowingEventForm(false)]}
       >
         {event.name}
       </div>


### PR DESCRIPTION
# Description
added setView false and setForm false to cause one modal to close the other in event view to remedy double modal displaying

# Steps to test

1. Fetch the JD-event-form-mod branch and switch to it
2. Start client
3. navigate to localhost:3000/events
4. click an event to view it
5. click a + to open the event adding modal > the 1st modal should be closed
6. click an event again to view it's details > the form should close
